### PR TITLE
Update running-hrea-backend.md

### DIFF
--- a/running-hrea-backend.md
+++ b/running-hrea-backend.md
@@ -74,7 +74,7 @@ echo \"pass\" | hc sandbox --piped create -n 1 -d hrea_tester network quic
 Install the hREA hApp to your holochain sandbox. Make sure you use the right path to wherever on your filesystem you have `hrea_suite.happ` file that you downloaded.
 
 ```
-echo \"pass\" | hc sandbox --piped call install-app-bundle ./hrea_suite.happ
+echo \"pass\" | hc sandbox --piped call install-app ./hrea_suite.happ
 ```
 
 


### PR DESCRIPTION
Updated the "hc sandbox call install-app-bundle" to "hc sandbox call install-app" because "install-app-bundle" is not in "hc sandbox call --help" menu