### PR TITLE
docs: update hREA references from v0.3.3 to v0.3.4

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,12 +7,12 @@ description: >-
 
 # Quick Start: hREA Integration
 
-A step-by-step guide to integrating **hREA v0.3.3** into your scaffolded Holochain application.
+A step-by-step guide to integrating **[hREA v0.3.4](https://github.com/holochain/hREA/releases/tag/v0.3.4)** into your scaffolded Holochain application.
 
 > **⚠️ Version Compatibility Notice**:
-> - **hREA v0.3.3** is compatible with **Holochain v0.5.x**
+> - **hREA v0.3.4** is compatible with **Holochain v0.6.x**
 >
-> This guide is specifically designed for **hREA version 0.3.3**. Different versions may require different integration steps.
+> This guide is specifically designed for **hREA version 0.3.4**. Different versions may require different integration steps.
 
 
 ## Prerequisites
@@ -58,4 +58,3 @@ For more detailed scaffolding instructions, you can refer to the official docume
 ## Next Steps
 
 Once you have scaffolded your new application, you are ready to begin integrating the hREA modules. The next section, the **[Integration Guide](integration-guide.md)**, will walk you through the process of adding the hREA DNA to your project and configuring it correctly.
-

--- a/integration-guide.md
+++ b/integration-guide.md
@@ -60,7 +60,7 @@ You need to download the pre-compiled hREA DNA and place it in your `workdir`. A
   "scripts": {
     "postinstall": "npm run download-hrea",
     // other scripts...
-    "download-hrea": "[ ! -f \"workdir/hrea.dna\" ] && curl -L --output workdir/hrea.dna https://github.com/h-REA/hREA/releases/download/happ-0.3.3-beta/hrea.dna; exit 0"
+    "download-hrea": "[ ! -f \"workdir/hrea.dna\" ] && curl -L --output workdir/hrea.dna https://github.com/h-REA/hREA/releases/download/happ-0.3.4-beta/hrea.dna; exit 0"
   }
 }
 ```
@@ -80,12 +80,12 @@ To communicate with the hREA DNA from your user interface, you will need to add 
 {
   "dependencies": {
     "@apollo/client": "^3.7.0",
-    "@valueflows/vf-graphql-holochain": "^0.0.4-alpha.4",
+    "@valueflows/vf-graphql-holochain": "^0.600.0-rc.0",
     "graphql": "^16.6.0"
   }
 }
 ```
-*Note: The versions above are compatible with hREA v0.3.3. Check for the latest compatible versions if you are using a different release.*
+*Note: The versions above are compatible with hREA v0.3.4. Check for the latest compatible versions if you are using a different release.*
 
 **Key dependencies explained:**
 - `@apollo/client`: A powerful GraphQL client that helps manage data fetching, caching, and state.
@@ -100,4 +100,4 @@ npm install  # or your chosen package manager
 
 ## Next Steps
 
-With the backend configuration complete, you are now ready to set up the client-side integration and start interacting with hREA from your UI. The next section, **[Basic Usage with Lit](basic-usage-lit.md)**, provides a complete, framework-agnostic example of how to connect to Holochain and hREA. 
+With the backend configuration complete, you are now ready to set up the client-side integration and start interacting with hREA from your UI. The next section, **[Basic Usage with Lit](basic-usage-lit.md)**, provides a complete, framework-agnostic example of how to connect to Holochain and hREA.

--- a/thinking-and-expressing-valueflows.md
+++ b/thinking-and-expressing-valueflows.md
@@ -7,13 +7,13 @@ description: >-
 
 # Thinking & Expressing ValueFlows
 
-If you have gone through the [Quick Start - API Explorer](quick-start.md) setup, you will be seeing something like the following screen.
+If you have gone through the [Quick Start](index.md) and [Integration Guide](integration-guide.md) to set up your hREA development environment, you will have access to a GraphQL playground interface to explore the API interactively.
 
 ![a web browser with 3 panels lined up horizontally, the left has code in it, the middle is empty, and right has some developer documentation](https://i.imgur.com/14flkez.png)
 
 It is a user interface, but isn't an "end user application". It is a "[graphiql](https://github.com/graphql/graphiql)" explorer (the "i" stands for "interactive"), built for mostly for engaging as a developer with a ["graphql"](https://graphql.org/) application programming interface (API). However, anyone can use it, and you're encouraged to stick with this, and see what you can do.
 
-This interface is super handy for testing and getting to know the ValueFlows data structures and functions.
+This interface is super handy for testing and getting to know the ValueFlows data structures and functions. For a complete working example, you can also follow the [Basic Usage with Lit](basic-usage-lit.md) guide which shows how to build a functional UI that connects to hREA.
 
 We can imagine a different "end user interface" making the same underlying graphql queries and mutations as we will make using this more developer-centric user interface.
 
@@ -125,7 +125,7 @@ Because we're going to need valid agent `ID`s for `provider` and `receiver` we c
 Use the following query in order to retrieve your own agent ID.&#x20;
 
 {% hint style="warning" %}
-This will ONLY work if you have gone through the first two steps of the [Quick Start - API Explorer](quick-start.md) tutorial, or otherwise called `associateMyAgent`
+This will ONLY work if you have set up your hREA development environment by following the [Quick Start](index.md) and [Integration Guide](integration-guide.md), and have called `associateMyAgent` to link your agent identity
 {% endhint %}
 
 ```graphql


### PR DESCRIPTION
## Summary
- Update all hREA version references from v0.3.3 to v0.3.4
- Update Holochain compatibility notes to v0.6.x
- Update download URLs to point to the hREA v0.3.4-beta release
- Update GraphQL client dependency to latest compatible version (@valueflows/vf-graphql-holochain v0.600.0-rc.0)
- Improve cross-references and documentation consistency throughout setup guides

## Changes Made
- **index.md**: Updated quick start guide with new version information and compatibility notes
- **integration-guide.md**: Updated download scripts and dependency versions for v0.3.4
- **thinking-and-expressing-valueflows.md**: Updated cross-references to point to correct documentation sections

## Test Plan
- [ ] Verify download URLs point to correct hREA v0.3.4-beta release
- [ ] Confirm Holochain v0.6.x compatibility documentation is accurate
- [ ] Test that dependency versions are compatible with hREA v0.3.4
- [ ] Validate all cross-references point to existing documentation sections